### PR TITLE
Implemented --nvidiaClosedClamshellPatch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ Specify that NVIDIA eGPU support shall be unlocked. **patch by @goalque**
 The IOPCITunnelled Patch tells the script to make the Mac compatible with NVIDIA eGPUs.  
 This is only required for macOS 10.3.6+. This might cause issues/crashes with AMD graphics cards (external).
 
+`--nvidiaClosedClamshellPatch | -L`
+
+Enables support for closed-clamshell mode when running with an NVIDIA eGPU. **patch by @sashavol**
+
 `--unlockT82 | -T`
 
 Specify that the T82 chipsets shall be unlocked.  


### PR DESCRIPTION
This is a patch I applied to this script to enable [closed-clamshell](https://support.apple.com/en-us/HT201834) mode with my NVIDIA eGPU. 

In IOGraphicsFamily's [IOFramebuffer](https://opensource.apple.com/source/IOGraphics/IOGraphics-530.9/IOGraphicsFamily/IOFramebuffer.cpp.auto.html) the line of code `gIOGDebugFlags |= kIOGDbgNoClamshellOffline` (only executed when an NVIDIA GPU is detected) causes closed-clamshell mode to be disabled, so when I close the macbook's lid the internal display doesn't get disabled. 

This patch adds an optional (not installed by default) package `--nvidiaClosedClamshellPatch` to install a patch that NOPs out this line of code.

(I understand the repository hasn't been updated in some time so no big deal if this can't be merged at the time, just contributing this in case it's useful).